### PR TITLE
Fixed nested stripe response

### DIFF
--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -18,7 +18,7 @@ defmodule Stripe.Util do
   end
 
   defp convert_value(key, format, map) when is_map(format) do
-    stripe_map_to_struct(format.module, map)
+    stripe_map_to_struct(format.module, map[key)
   end
   defp convert_value(key, :metadata, map) do
     map


### PR DESCRIPTION
Instead of passing the whole map to the nested structure, only the pertinent submap should be sent to be mapped over for the struct.